### PR TITLE
add role only when new joining members accept the rules of membership screening

### DIFF
--- a/utils/role-selector/build.gradle.kts
+++ b/utils/role-selector/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "dev.schlaubi.mikbot"
-version = "2.0.1"
+version = "2.0.2"
 
 mikbotPlugin {
     description.set("Give Roles on a specific Event")

--- a/utils/role-selector/src/main/kotlin/dev/schlaubi/mikbot/utils/roleselector/RoleSelectorPlugin.kt
+++ b/utils/role-selector/src/main/kotlin/dev/schlaubi/mikbot/utils/roleselector/RoleSelectorPlugin.kt
@@ -8,7 +8,8 @@ import dev.schlaubi.mikbot.plugin.api.settings.SettingsExtensionPoint
 import dev.schlaubi.mikbot.plugin.api.settings.SettingsModule
 import dev.schlaubi.mikbot.utils.roleselector.command.autoRoleCommand
 import dev.schlaubi.mikbot.utils.roleselector.command.roleselection.createRoleMessageCommand
-import dev.schlaubi.mikbot.utils.roleselector.listener.guildMemeberAddListener
+import dev.schlaubi.mikbot.utils.roleselector.listener.guildMemberAddListener
+import dev.schlaubi.mikbot.utils.roleselector.listener.guildMemberUpdateListener
 import dev.schlaubi.mikbot.utils.roleselector.listener.interactionCreateListener
 import org.pf4j.Extension
 import com.kotlindiscord.kord.extensions.extensions.Extension as KordExtension
@@ -32,7 +33,8 @@ class RoleSelectorModule : KordExtension() {
     override val name: String = "role selector event handler"
 
     override suspend fun setup() {
-        guildMemeberAddListener()
+        guildMemberAddListener()
+        guildMemberUpdateListener()
         interactionCreateListener()
     }
 }

--- a/utils/role-selector/src/main/kotlin/dev/schlaubi/mikbot/utils/roleselector/listener/GuildMemberAddListener.kt
+++ b/utils/role-selector/src/main/kotlin/dev/schlaubi/mikbot/utils/roleselector/listener/GuildMemberAddListener.kt
@@ -2,21 +2,38 @@ package dev.schlaubi.mikbot.utils.roleselector.listener
 
 import com.kotlindiscord.kord.extensions.extensions.event
 import dev.kord.core.behavior.channel.createMessage
+import dev.kord.core.entity.Guild
+import dev.kord.core.entity.Member
 import dev.kord.core.event.guild.MemberJoinEvent
+import dev.kord.core.event.guild.MemberUpdateEvent
 import dev.kord.rest.request.RestRequestException
 import dev.schlaubi.mikbot.utils.roleselector.RoleSelectorDatabase
 import dev.schlaubi.mikbot.utils.roleselector.RoleSelectorModule
 
-suspend fun RoleSelectorModule.guildMemeberAddListener() = event<MemberJoinEvent> {
+suspend fun RoleSelectorModule.guildMemberAddListener() = event<MemberJoinEvent> {
     action {
-        val role = RoleSelectorDatabase.autoRoleCollection.findOneById(event.guildId) ?: return@action
-        try {
-            event.member.addRole(role.roleId, "Auto Role")
-        } catch (ex: RestRequestException) {
-            event.guild.asGuild().owner.getDmChannel().createMessage {
-                content = "Something went wrong while trying to give the set Auto Role to the new joining Member\n" +
-                    "Error: ${ex.error?.message}"
-            }
+        if (event.member.isPending) return@action
+
+        addRole(event.member, event.getGuild())
+    }
+}
+
+suspend fun RoleSelectorModule.guildMemberUpdateListener() = event<MemberUpdateEvent> {
+    action {
+        if (event.old?.isPending == true && !event.member.isPending) {
+            addRole(event.member, event.getGuild())
+        }
+    }
+}
+
+private suspend fun addRole(member: Member, guild: Guild) {
+    val role = RoleSelectorDatabase.autoRoleCollection.findOneById(guild.id) ?: return
+    try {
+        member.addRole(role.roleId, "Auto Role")
+    } catch (ex: RestRequestException) {
+        guild.asGuild().owner.getDmChannel().createMessage {
+            content = "Something went wrong while trying to give the set Auto Role to the new joining Member\n" +
+                    "Error: ```${ex.error?.message}```"
         }
     }
 }


### PR DESCRIPTION
Previously when a new Member joined, the bot gave the Role to the user and the Membership screening got skipped because discord skips it when the user receives a role